### PR TITLE
Return NXDOMAIN instead of REFUSED in service domain.

### DIFF
--- a/lib/mpdnsd.pm
+++ b/lib/mpdnsd.pm
@@ -132,6 +132,8 @@ sub reply_handler {
     if (lc($qname) =~ /^(.+)\.(\w+)\.\Q${service_domain}\E$/) {
         $suffix = $1;
         $service = $2;
+    } elsif (lc($qname) =~ /\.\Q${service_domain}\E$/) {
+        return ('NXDOMAIN', \@ans, \@auth, \@add, {aa => 1});
     } else {
         return ('REFUSED', \@ans, \@auth, \@add, {aa => 1});
     }
@@ -143,7 +145,7 @@ sub reply_handler {
         }
     }
 
-    return ('REFUSED', \@ans, \@auth, \@add, {aa => 1});
+    return ('NXDOMAIN', \@ans, \@auth, \@add, {aa => 1});
 VALID:
 
     my $rcode = 'SERVFAIL';

--- a/t/02_reply_handler.t
+++ b/t/02_reply_handler.t
@@ -27,7 +27,7 @@ is($rcode, 'REFUSED', 'invalid service domain');
 $dn = 'invalid.com.r2.mp.kkcube.com';
 $query = Net::DNS::Packet->new($dn, 'A', 'IN');
 ($rcode, $ans, $auth, $add, $opt) = mpdnsd::reply_handler($dn, 'IN', 'A', '127.0.0.1', $query, $conn);
-is($rcode, 'REFUSED', 'invalid return domain');
+is($rcode, 'NXDOMAIN', 'invalid return domain');
 
 $dn = 'mp.kkcube.com';
 $query = Net::DNS::Packet->new($dn, 'NS', 'IN');
@@ -37,7 +37,7 @@ is($rcode, 'NOERROR', 'nameserver');
 $dn = 'asn.mp.kkcube.com';
 $query = Net::DNS::Packet->new($dn, 'NS', 'IN');
 ($rcode, $ans, $auth, $add, $opt) = mpdnsd::reply_handler($dn, 'IN', 'NS', '127.0.0.1', $query, $conn);
-is($rcode, 'REFUSED', 'without return domain');
+is($rcode, 'NXDOMAIN', 'without return domain');
 
 $dn = 'test.kkcube.com.invalid.mp.kkcube.com';
 $query = Net::DNS::Packet->new($dn, 'NS', 'IN');

--- a/t/02_reply_handler.t
+++ b/t/02_reply_handler.t
@@ -34,6 +34,11 @@ $query = Net::DNS::Packet->new($dn, 'NS', 'IN');
 ($rcode, $ans, $auth, $add, $opt) = mpdnsd::reply_handler($dn, 'IN', 'NS', '127.0.0.1', $query, $conn);
 is($rcode, 'NOERROR', 'nameserver');
 
+$dn = 'asn.mp.kkcube.com';
+$query = Net::DNS::Packet->new($dn, 'NS', 'IN');
+($rcode, $ans, $auth, $add, $opt) = mpdnsd::reply_handler($dn, 'IN', 'NS', '127.0.0.1', $query, $conn);
+is($rcode, 'REFUSED', 'without return domain');
+
 $dn = 'test.kkcube.com.invalid.mp.kkcube.com';
 $query = Net::DNS::Packet->new($dn, 'NS', 'IN');
 ($rcode, $ans, $auth, $add, $opt) = mpdnsd::reply_handler($dn, 'IN', 'NS', '127.0.0.1', $query, $conn);


### PR DESCRIPTION
https://tools.ietf.org/html/rfc1035
```
RCODE
        3               Name Error - Meaningful only for
                        responses from an authoritative name
                        server, this code signifies that the
                        domain name referenced in the query does
                        not exist.
        5               Refused - The name server refuses to
                        perform the specified operation for
                        policy reasons.  For example, a name
                        server may not wish to provide the
                        information to the particular requester,
                        or a name server may not wish to perform
                        a particular operation (e.g., zone
                        transfer) for particular data.
```